### PR TITLE
#42 Httpreq returns the response object

### DIFF
--- a/httpreq/httpreq.go
+++ b/httpreq/httpreq.go
@@ -135,13 +135,6 @@ func (r *HttpReq) CallWithTransport(v interface{}, transport *http.Transport) (i
 	return r.call(v, httpClient)
 }
 
-func (r *HttpReq) SetGlobalTransport(v interface{}, transport *http.Transport) (int, error) {
-	if defaultClient != nil {
-		defaultClient.Transport = transport
-	}
-	return r.call(v, defaultClient)
-}
-
 func (r *HttpReq) call(v interface{}, httpClient *http.Client) (int, error) {
 	if r.err != nil {
 		return 0, r.err
@@ -165,5 +158,33 @@ func (r *HttpReq) call(v interface{}, httpClient *http.Client) (int, error) {
 		}
 	}
 	return resp.StatusCode, nil
+
+}
+
+func (r *HttpReq) RawCall() (*http.Response, error) {
+	return r.rawCall(defaultClient)
+}
+
+func (r *HttpReq) RawCallWithClient(httpClient *http.Client) (*http.Response, error) {
+	return r.rawCall(httpClient)
+}
+
+func (r *HttpReq) RawCallWithTransport(transport *http.Transport) (*http.Response, error) {
+	httpClient := &http.Client{Transport: transport}
+	return r.rawCall(httpClient)
+}
+
+func (r *HttpReq) rawCall(httpClient *http.Client) (*http.Response, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	if len(r.Req.Header.Get("Content-Type")) == 0 {
+		r.Req.Header.Set("Content-Type", DataTypeFactory{}.New(r.ReqDataType).contentType())
+	}
+	resp, err := httpClient.Do(r.Req)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
 
 }


### PR DESCRIPTION
Sometimes, we need to get more information about the response,
such as: when getting the WeChat bill,

    the correct response, Content-Type is application/x-gzip,
    error response is text/plain; charset=utf-8
